### PR TITLE
Add filtering to AuditLog and tests

### DIFF
--- a/code/back/src/main/java/com/tfg/controller/AuditLogController.java
+++ b/code/back/src/main/java/com/tfg/controller/AuditLogController.java
@@ -36,4 +36,15 @@ public class AuditLogController {
                 .map(AuditLogMapper::toDto)
                 .collect(Collectors.toList());
     }
+
+    @Operation(
+            summary = "Obtener logs por acción",
+            description = "Devuelve los registros filtrados por el tipo de acción"
+    )
+    @GetMapping("/action/{action}")
+    public List<AuditLogDTO> getLogsByAction(@PathVariable String action) {
+        return auditLogService.getLogsByAction(action).stream()
+                .map(AuditLogMapper::toDto)
+                .collect(Collectors.toList());
+    }
 }

--- a/code/back/src/main/java/com/tfg/repository/AuditLogRepository.java
+++ b/code/back/src/main/java/com/tfg/repository/AuditLogRepository.java
@@ -4,6 +4,15 @@ import com.tfg.entity.AuditLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
+    /**
+     * Busca logs de auditoría por tipo de acción.
+     *
+     * @param action acción realizada (CREATE, UPDATE, DELETE, etc.)
+     * @return lista de logs que coinciden con la acción
+     */
+    List<AuditLog> findByAction(String action);
 }

--- a/code/back/src/main/java/com/tfg/service/AuditLogService.java
+++ b/code/back/src/main/java/com/tfg/service/AuditLogService.java
@@ -6,4 +6,12 @@ import java.util.List;
 
 public interface AuditLogService {
     List<AuditLog> getAllLogs();
+
+    /**
+     * Devuelve los logs filtrando por acción.
+     *
+     * @param action tipo de acción realizada
+     * @return lista de logs correspondientes
+     */
+    List<AuditLog> getLogsByAction(String action);
 }

--- a/code/back/src/main/java/com/tfg/service/impl/AuditLogServiceImpl.java
+++ b/code/back/src/main/java/com/tfg/service/impl/AuditLogServiceImpl.java
@@ -20,4 +20,9 @@ public class AuditLogServiceImpl implements AuditLogService {
     public List<AuditLog> getAllLogs() {
         return auditLogRepository.findAll();
     }
+
+    @Override
+    public List<AuditLog> getLogsByAction(String action) {
+        return auditLogRepository.findByAction(action);
+    }
 }

--- a/code/back/src/test/java/com/tfg/controller/AuditLogControllerTest.java
+++ b/code/back/src/test/java/com/tfg/controller/AuditLogControllerTest.java
@@ -1,0 +1,36 @@
+package com.tfg.controller;
+
+import com.tfg.entity.AuditLog;
+import com.tfg.service.AuditLogService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuditLogController.class)
+class AuditLogControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuditLogService auditLogService;
+
+    @Test
+    void testGetLogsByAction() throws Exception {
+        AuditLog log = new AuditLog();
+        log.setAction("CREATE");
+        when(auditLogService.getLogsByAction("CREATE")).thenReturn(List.of(log));
+
+        mockMvc.perform(get("/api/audit-logs/action/CREATE"))
+                .andExpect(status().isOk());
+    }
+}
+

--- a/code/back/src/test/java/com/tfg/service/impl/AuditLogServiceImplTest.java
+++ b/code/back/src/test/java/com/tfg/service/impl/AuditLogServiceImplTest.java
@@ -1,0 +1,62 @@
+package com.tfg.service.impl;
+
+import com.tfg.entity.AuditLog;
+import com.tfg.repository.AuditLogRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+class AuditLogServiceImplTest {
+
+    private AuditLogServiceImpl auditLogService;
+
+    @Mock
+    private AuditLogRepository auditLogRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        auditLogService = new AuditLogServiceImpl(auditLogRepository);
+    }
+
+    @Test
+    void testGetAllLogs() {
+        AuditLog log1 = new AuditLog();
+        log1.setId(1L);
+        log1.setAction("CREATE");
+
+        AuditLog log2 = new AuditLog();
+        log2.setId(2L);
+        log2.setAction("DELETE");
+
+        List<AuditLog> logs = Arrays.asList(log1, log2);
+        when(auditLogRepository.findAll()).thenReturn(logs);
+
+        List<AuditLog> result = auditLogService.getAllLogs();
+
+        assertEquals(2, result.size());
+        assertEquals("CREATE", result.get(0).getAction());
+    }
+
+    @Test
+    void testGetLogsByAction() {
+        AuditLog log1 = new AuditLog();
+        log1.setId(1L);
+        log1.setAction("CREATE");
+
+        when(auditLogRepository.findByAction("CREATE")).thenReturn(List.of(log1));
+
+        List<AuditLog> result = auditLogService.getLogsByAction("CREATE");
+
+        assertEquals(1, result.size());
+        assertEquals("CREATE", result.get(0).getAction());
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement filtering logs by action
- expose new controller endpoint
- provide repository query
- add service and controller unit tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6845a803ed188327a897d50c60087ff0