### PR TITLE
Add controller unit tests

### DIFF
--- a/code/back/src/test/java/com/tfg/controller/AuthControllerTest.java
+++ b/code/back/src/test/java/com/tfg/controller/AuthControllerTest.java
@@ -1,0 +1,62 @@
+package com.tfg.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tfg.security.jwt.JwtUtils;
+import com.tfg.security.model.JwtRequest;
+import com.tfg.security.service.CustomUserDetailsService;
+import com.tfg.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.springframework.http.MediaType;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthenticationManager authenticationManager;
+
+    @MockBean
+    private CustomUserDetailsService userDetailsService;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private JwtUtils jwtUtils;
+
+    @Test
+    void testAuthenticate() throws Exception {
+        JwtRequest request = new JwtRequest();
+        request.setUsername("user");
+        request.setPassword("pass");
+
+        UserDetails userDetails = User.withUsername("user").password("pass").roles("USER").build();
+
+        doNothing().when(authenticationManager).authenticate(any(UsernamePasswordAuthenticationToken.class));
+        when(userDetailsService.loadUserByUsername("user")).thenReturn(userDetails);
+        when(userService.getWarehouseIdByUsername("user")).thenReturn(1L);
+        when(userService.getPermissionsByUsername("user")).thenReturn("ROLE_USER");
+        when(jwtUtils.generateToken("user", "ROLE_USER", 1L)).thenReturn("token");
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+}

--- a/code/back/src/test/java/com/tfg/controller/CategoryControllerTest.java
+++ b/code/back/src/test/java/com/tfg/controller/CategoryControllerTest.java
@@ -1,0 +1,33 @@
+package com.tfg.controller;
+
+import com.tfg.entity.Category;
+import com.tfg.service.CategoryService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CategoryController.class)
+class CategoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CategoryService categoryService;
+
+    @Test
+    void testGetAllCategories() throws Exception {
+        when(categoryService.getAllCategories()).thenReturn(List.of(new Category()));
+
+        mockMvc.perform(get("/api/categories/get"))
+                .andExpect(status().isOk());
+    }
+}

--- a/code/back/src/test/java/com/tfg/controller/InventoryAlertControllerTest.java
+++ b/code/back/src/test/java/com/tfg/controller/InventoryAlertControllerTest.java
@@ -1,0 +1,33 @@
+package com.tfg.controller;
+
+import com.tfg.entity.InventoryAlert;
+import com.tfg.service.InventoryAlertService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(InventoryAlertController.class)
+class InventoryAlertControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private InventoryAlertService alertService;
+
+    @Test
+    void testGetAllAlerts() throws Exception {
+        when(alertService.getAllAlerts()).thenReturn(List.of(new InventoryAlert()));
+
+        mockMvc.perform(get("/api/inventory-alerts/get"))
+                .andExpect(status().isOk());
+    }
+}

--- a/code/back/src/test/java/com/tfg/controller/InventoryControllerTest.java
+++ b/code/back/src/test/java/com/tfg/controller/InventoryControllerTest.java
@@ -1,0 +1,33 @@
+package com.tfg.controller;
+
+import com.tfg.entity.Inventory;
+import com.tfg.service.InventoryService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(InventoryController.class)
+class InventoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private InventoryService inventoryService;
+
+    @Test
+    void testGetAllInventory() throws Exception {
+        when(inventoryService.getAllInventories()).thenReturn(List.of(new Inventory()));
+
+        mockMvc.perform(get("/api/inventory/get"))
+                .andExpect(status().isOk());
+    }
+}

--- a/code/back/src/test/java/com/tfg/controller/ProductControllerTest.java
+++ b/code/back/src/test/java/com/tfg/controller/ProductControllerTest.java
@@ -1,0 +1,33 @@
+package com.tfg.controller;
+
+import com.tfg.entity.Product;
+import com.tfg.service.ProductService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProductController.class)
+class ProductControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ProductService productService;
+
+    @Test
+    void testGetAllProducts() throws Exception {
+        when(productService.getAllProducts()).thenReturn(List.of(new Product()));
+
+        mockMvc.perform(get("/api/products/get"))
+                .andExpect(status().isOk());
+    }
+}

--- a/code/back/src/test/java/com/tfg/controller/ReportControllerTest.java
+++ b/code/back/src/test/java/com/tfg/controller/ReportControllerTest.java
@@ -1,0 +1,45 @@
+package com.tfg.controller;
+
+import com.tfg.dto.EstadisticasDTO;
+import com.tfg.service.EstadisticasService;
+import com.tfg.service.ReportService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ReportController.class)
+class ReportControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private EstadisticasService estadisticasService;
+
+    @MockBean
+    private ReportService reportService;
+
+    @Test
+    void testDescargarPDF() throws Exception {
+        when(estadisticasService.obtenerEstadisticas(anyString(), any(), any(), any(), any()))
+                .thenReturn(new EstadisticasDTO());
+        when(reportService.generarEstadisticasPDF(any(EstadisticasDTO.class)))
+                .thenReturn(new byte[]{1,2,3});
+
+        mockMvc.perform(get("/api/reports/estadisticas/pdf")
+                .param("sku", "ABC")
+                .param("almacen", "1")
+                .param("categoria", "CAT")
+                .param("fechaInicio", "2024-01-01")
+                .param("fechaFin", "2024-02-01"))
+                .andExpect(status().isOk());
+    }
+}

--- a/code/back/src/test/java/com/tfg/controller/RoleControllerTest.java
+++ b/code/back/src/test/java/com/tfg/controller/RoleControllerTest.java
@@ -1,0 +1,33 @@
+package com.tfg.controller;
+
+import com.tfg.dto.RoleDTO;
+import com.tfg.service.RoleService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RoleController.class)
+class RoleControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RoleService roleService;
+
+    @Test
+    void testGetAllRoles() throws Exception {
+        when(roleService.getAllRoles()).thenReturn(List.of(new RoleDTO()));
+
+        mockMvc.perform(get("/api/roles"))
+                .andExpect(status().isOk());
+    }
+}

--- a/code/back/src/test/java/com/tfg/controller/TransactionControllerTest.java
+++ b/code/back/src/test/java/com/tfg/controller/TransactionControllerTest.java
@@ -1,0 +1,33 @@
+package com.tfg.controller;
+
+import com.tfg.entity.Transaction;
+import com.tfg.service.TransactionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TransactionController.class)
+class TransactionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TransactionService transactionService;
+
+    @Test
+    void testGetAllTransactions() throws Exception {
+        when(transactionService.getAllTransactions()).thenReturn(List.of(new Transaction()));
+
+        mockMvc.perform(get("/api/transactions/get"))
+                .andExpect(status().isOk());
+    }
+}

--- a/code/back/src/test/java/com/tfg/controller/UserControllerTest.java
+++ b/code/back/src/test/java/com/tfg/controller/UserControllerTest.java
@@ -1,0 +1,33 @@
+package com.tfg.controller;
+
+import com.tfg.entity.User;
+import com.tfg.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Test
+    void testGetAllUsers() throws Exception {
+        when(userService.getAllUsers()).thenReturn(List.of(new User()));
+
+        mockMvc.perform(get("/api/users"))
+                .andExpect(status().isOk());
+    }
+}

--- a/code/back/src/test/java/com/tfg/controller/WarehouseControllerTest.java
+++ b/code/back/src/test/java/com/tfg/controller/WarehouseControllerTest.java
@@ -1,0 +1,33 @@
+package com.tfg.controller;
+
+import com.tfg.entity.Warehouse;
+import com.tfg.service.WarehouseService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(WarehouseController.class)
+class WarehouseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private WarehouseService warehouseService;
+
+    @Test
+    void testGetAllWarehouses() throws Exception {
+        when(warehouseService.getAllWarehouses()).thenReturn(List.of(new Warehouse()));
+
+        mockMvc.perform(get("/api/warehouses/get"))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## Summary
- add missing controller tests for backend

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6845aa1dd3908327a92140a48a7d55f9